### PR TITLE
feature/oneof

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ res := e.Evaluate(props)
 // res == true
 ```
 
+# Comparators
+* `eq` will return true if `a == b`
+* `neq` will return true if `a != b`
+* `lt` will return true if `a < b`
+* `lte` will return true if `a <= b`
+* `gt` will return true if `a > b`
+* `gte` will return true if `a >= b`
+* `contains` will return true if `a` contains `b`
+* `oneof` will return true if `a` is one of `b`
+
+`contains` is different than `oneof` in that `contains` expects the first argument to be a slice, and `oneof` expects the second argument to be a slice.
+
 # Benchmarks
 
 |Benchmark|N|Speed|

--- a/comparators.go
+++ b/comparators.go
@@ -122,7 +122,9 @@ func greaterThanEqual(a, b interface{}) bool {
 	return !lessThan(a, b)
 }
 
-// contains will return true if b is contained in a
+// contains will return true if a contains b. We assume
+// that the first interface is a slice. If you need b to be a slice
+// consider using oneOf
 func contains(a, b interface{}) bool {
 	t1 := reflect.TypeOf(a)
 	t2 := reflect.TypeOf(b)
@@ -163,8 +165,6 @@ func contains(a, b interface{}) bool {
 	}
 }
 
-// containsString will type assert a to []string, and assume b
-// is a string
 func containsString(a, b interface{}) bool {
 	as, ok := a.([]string)
 	if !ok {
@@ -332,4 +332,9 @@ func containsFloat64(a, b interface{}) bool {
 		}
 	}
 	return false
+}
+
+// oneOf will return true if b contains a
+func oneOf(a, b interface{}) bool {
+	return contains(b, a)
 }

--- a/comparators_test.go
+++ b/comparators_test.go
@@ -198,3 +198,20 @@ func BenchmarkContainsLong50000(b *testing.B) {
 		contains(list, "49999")
 	}
 }
+
+func TestOneOf(t *testing.T) {
+	cases := []testCase{
+		testCase{args: []interface{}{"a", []string{"a", "b"}}, expected: true},
+		testCase{args: []interface{}{"c", []string{"a", "b"}}, expected: false},
+		testCase{args: []interface{}{1, []string{"a", "b"}}, expected: false},
+		testCase{args: []interface{}{1, []int{1, 2}}, expected: true},
+		testCase{args: []interface{}{3, []int{1, 2}}, expected: false},
+		testCase{args: []interface{}{1.01, []float64{1.01, 1.02}}, expected: true},
+	}
+	for i, c := range cases {
+		res := oneOf(c.args[0], c.args[1])
+		if res != c.expected {
+			t.Fatalf("expected case %d to be %v, got %v", i, c.expected, res)
+		}
+	}
+}

--- a/rule.go
+++ b/rule.go
@@ -21,6 +21,7 @@ var defaultComparators = map[string]Comparator{
 	"lt":       lessThan,
 	"lte":      lessThanEqual,
 	"contains": contains,
+	"oneof":    oneOf,
 }
 
 // Rule is a our smallest unit of measure, each rule will be


### PR DESCRIPTION
I have decided to create a `oneof` operator, which is similar to `contains` but switches the order of the arguments.

This is helpful in the instance where your user properties are different, but you still want to perform a "search" operation.