### PR TITLE
fix/float64

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -2,6 +2,8 @@ package grules
 
 import (
 	"encoding/json"
+	"fmt"
+	"reflect"
 )
 
 const (
@@ -116,9 +118,39 @@ func (c Composite) evaluate(props map[string]interface{}, comps map[string]Compa
 // Evaluate will return true if the rule is true, false otherwise
 func (r Rule) evaluate(props map[string]interface{}, comps map[string]Comparator) bool {
 	// Make sure we can get a value from the props
-	val := pluck(props, r.Path)
-	if val == nil {
+	inter := pluck(props, r.Path)
+	if inter == nil {
 		return false
+	}
+
+	// This is an important step, we need to get numbers to their most
+	// precise type, because that is how the mapper works
+	var val interface{}
+	switch inter.(type) {
+	case uint:
+		val = float64(inter.(uint))
+	case uint8:
+		val = float64(inter.(uint8))
+	case uint16:
+		val = float64(inter.(uint16))
+	case uint32:
+		val = float64(inter.(uint32))
+	case uint64:
+		val = float64(inter.(uint64))
+	case int:
+		val = float64(inter.(int))
+	case int8:
+		val = float64(inter.(int8))
+	case int16:
+		val = float64(inter.(int16))
+	case int32:
+		val = float64(inter.(int32))
+	case int64:
+		val = float64(inter.(int64))
+	case float32:
+		val = float64(inter.(float32))
+	default:
+		val = inter
 	}
 
 	comp, ok := comps[r.Comparator]
@@ -126,5 +158,6 @@ func (r Rule) evaluate(props map[string]interface{}, comps map[string]Comparator
 		return false
 	}
 
+	fmt.Println(reflect.TypeOf(val), reflect.TypeOf(r.Value))
 	return comp(val, r.Value)
 }

--- a/rule_test.go
+++ b/rule_test.go
@@ -1,6 +1,8 @@
 package grules
 
 import (
+	"encoding/json"
+	"reflect"
 	"testing"
 )
 
@@ -217,14 +219,14 @@ func TestEngineEvaluate(t *testing.T) {
 		e.Composites = []Composite{
 			Composite{
 				Operator: OperatorAnd,
-			Rules: []Rule{
-				Rule{
-					Comparator: "contains",
-					Path: "address.bedroom.furniture",
-					Value: "tv",
+				Rules: []Rule{
+					Rule{
+						Comparator: "contains",
+						Path:       "address.bedroom.furniture",
+						Value:      "tv",
+					},
 				},
 			},
-			},	
 		}
 		res := e.Evaluate(props)
 		if res != true {
@@ -276,6 +278,47 @@ func TestEngineEvaluate(t *testing.T) {
 		res := e.Evaluate(props)
 		if res != true {
 			t.Fatal("expected engine to pass")
+		}
+	})
+}
+
+func TestRuleUnmarshalJSON(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		b := []byte(`{"path":"name","comparator":"eq","value":"trevor"}`)
+		var r Rule
+		err := json.Unmarshal(b, &r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if reflect.TypeOf(r.Value).Kind() != reflect.String {
+			t.Fatal("expected value to be of type string")
+		}
+	})
+
+	t.Run("int64", func(t *testing.T) {
+		b := []byte(`{"path":"name","comparator":"eq","value":1}`)
+		var r Rule
+		err := json.Unmarshal(b, &r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if reflect.TypeOf(r.Value).Kind() != reflect.Int64 {
+			t.Fatal("expected value to be of type int64")
+		}
+	})
+
+	t.Run("float64", func(t *testing.T) {
+		b := []byte(`{"path":"name","comparator":"eq","value":1.1}`)
+		var r Rule
+		err := json.Unmarshal(b, &r)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if reflect.TypeOf(r.Value).Kind() != reflect.Float64 {
+			t.Fatal("expected value to be of type float64")
 		}
 	})
 }


### PR DESCRIPTION
When using the NewEngineFromJSON, we should not assume that integers are float64's like Go's default json does, we should try to separate integers, _I think_, maybe not. I just think it is awkward to have a model like

```
message User {
    string uuid = 1;
    string email = 2;

    // This number can be negative if the date is before Jan. 1, 1970
    int64 dob_unix = 4;
};
```

and have to type dob_unix as a double. This feels less bad.