### PR TITLE
Allow substring comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,25 +56,27 @@ When used for item-in-collection comparisons, `contains` expects the first argum
 
 | Benchmark                        | N          | Speed        | Used      | Allocs       |
 |----------------------------------|------------|--------------|-----------|--------------|
-| BenchmarkEqual-12                | 1000000000 | 5.22 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkNotEqual-12             | 2000000000 | 3.77 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkLessThan-12             | 2000000000 | 2.20 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkLessThanEqual-12        | 2000000000 | 1.95 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkGreaterThan-12          | 5000000000 | 1.95 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkGreaterThanEqual-12     | 2000000000 | 1.97 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkRegex-12                | 10000000   | 712 ns/op    | 740 B/op  | 11 allocs/op |
-| BenchmarkRegexPhone-12           | 1000000    | 3025 ns/op   | 3192 B/op | 30 allocs/op |
-| BenchmarkContains-12             | 1000000000 | 5.66 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkContainsLong50000-12    | 30000      | 157679 ns/op | 0 B/op    | 0 allocs/op  |
-| BenchmarkNotContains-12          | 500000000  | 11.5 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkNotContainsLong50000-12 | 30000      | 157437 ns/op | 0 B/op    | 0 allocs/op  |
-| BenchmarkOneOf-12                | 500000000  | 0.53 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkNoneOf-12               | 500000000  | 0.53 ns/op   | 0 B/op    | 0 allocs/op  |
-| BenchmarkPluckShallow-12         | 100000000  | 42.4 ns/op   | 16 B/op   | 1 allocs/op  |
-| BenchmarkPluckDeep-12            | 30000000   | 174 ns/op    | 112 B/op  | 1 allocs/op  |
-| BenchmarkRule_evaluate-12        | 100000000  | 51.7 ns/op   | 16 B/op   | 1 allocs/op  |
-| BenchmarkComposite_evaluate-12   | 100000000  | 58.9 ns/op   | 16 B/op   | 1 allocs/op  |
-| BenchmarkEngine_Evaluate-12      | 100000000  | 69.9 ns/op   | 16 B/op   | 1 allocs/op  |
+| BenchmarkEqual-12                | 650602549  | 5.52 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkNotEqual-12             | 876894124  | 4.09 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkLessThan-12             | 1000000000 | 2.84 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkLessThanEqual-12        | 1000000000 | 2.57 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkGreaterThan-12          | 1000000000 | 2.07 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkGreaterThanEqual-12     | 1000000000 | 2.86 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkRegex-12                | 4524237    | 793 ns/op    | 753 B/op  | 11 allocs/op |
+| BenchmarkRegexPhone-12           | 1000000    | 3338 ns/op   | 3199 B/op | 30 allocs/op |
+| BenchmarkContains-12             | 499627219  | 7.16 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkStringContains-12       | 405497102  | 8.87 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkContainsLong50000-12    | 18992      | 184016 ns/op | 0 B/op    | 0 allocs/op  |
+| BenchmarkNotContains-12          | 292932907  | 12.3 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkStringNotContains-12    | 392618857  | 9.14 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkNotContainsLong50000-12 | 19243      | 191787 ns/op | 0 B/op    | 0 allocs/op  |
+| BenchmarkOneOf-12                | 1000000000 | 1.80 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkNoneOf-12               | 1000000000 | 1.79 ns/op   | 0 B/op    | 0 allocs/op  |
+| BenchmarkPluckShallow-12         | 85997188   | 41.6 ns/op   | 16 B/op   | 1 allocs/op  |
+| BenchmarkPluckDeep-12            | 18789103   | 194 ns/op    | 112 B/op  | 1 allocs/op  |
+| BenchmarkRule_evaluate-12        | 69558996   | 51.1 ns/op   | 16 B/op   | 1 allocs/op  |
+| BenchmarkComposite_evaluate-12   | 59484760   | 55.7 ns/op   | 16 B/op   | 1 allocs/op  |
+| BenchmarkEngine_Evaluate-12      | 47892318   | 75.0 ns/op   | 16 B/op   | 1 allocs/op  |
 
 To run benchmarks:
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,19 @@ res := e.Evaluate(props)
 - `gt` will return true if `a > b`
 - `gte` will return true if `a >= b`
 - `contains` will return true if `a` contains `b`
+- `ncontains` will return true if `a` does not contain `b`
 - `oneof` will return true if `a` is one of `b`
+- `noneof` will return true if `a` is not one of `b`
 - `regex` will return true if `a` matches `b`
 
-`contains` is different than `oneof` in that `contains` expects the first argument to be a slice, and `oneof` expects the second argument to be a slice.
+`contains` and `ncontains` work for substring comparisons as well as item-in-collection comparisons.
+
+When used for item-in-collection comparisons, `contains` expects the first argument to be a slice. `contains` is different than `oneof` in that `oneof` expects the second argument to be a slice.
 
 # Benchmarks
 
 | Benchmark                        | N          | Speed        | Used      | Allocs       |
-| -------------------------------- | ---------- | ------------ | --------- | ------------ |
+|----------------------------------|------------|--------------|-----------|--------------|
 | BenchmarkEqual-12                | 1000000000 | 5.22 ns/op   | 0 B/op    | 0 allocs/op  |
 | BenchmarkNotEqual-12             | 2000000000 | 3.77 ns/op   | 0 B/op    | 0 allocs/op  |
 | BenchmarkLessThan-12             | 2000000000 | 2.20 ns/op   | 0 B/op    | 0 allocs/op  |

--- a/comparators.go
+++ b/comparators.go
@@ -1,6 +1,9 @@
 package grules
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // Comparator is a function that should evaluate two values and return
 // the true if the comparison is true, or false if the comparison is
@@ -172,6 +175,8 @@ func contains(a, b interface{}) bool {
 				}
 			}
 			return false
+		case string:
+			return strings.Contains(a.(string), b.(string))
 		default:
 			return false
 		}
@@ -221,6 +226,8 @@ func notContains(a, b interface{}) bool {
 				}
 			}
 			return true
+		case string:
+			return !strings.Contains(a.(string), b.(string))
 		default:
 			return false
 		}

--- a/comparators.go
+++ b/comparators.go
@@ -154,9 +154,8 @@ func regex(a, b interface{}) bool {
 	}
 }
 
-// contains will return true if a contains b. We assume
-// that the first interface is a slice. If you need b to be a slice
-// consider using oneOf
+// contains will return true if a contains b. a can be a slice
+// or a string.  If you need b to be a slice consider using oneOf
 func contains(a, b interface{}) bool {
 	switch bt := b.(type) {
 	case string:
@@ -207,7 +206,7 @@ func contains(a, b interface{}) bool {
 
 // notContains will return true if the b is not contained a. This will also return
 // true if a is a slice of different types than b. It will return false if a
-// is not a slice.
+// is not a slice or a string.
 func notContains(a, b interface{}) bool {
 	switch bt := b.(type) {
 	case string:
@@ -255,7 +254,7 @@ func notContains(a, b interface{}) bool {
 	}
 }
 
-// oneOf will return true if b contains a
+// oneOf will return true if b (slice) contains a
 func oneOf(a, b interface{}) bool {
 	m, ok := b.(map[interface{}]struct{})
 	if !ok {
@@ -270,7 +269,7 @@ func oneOf(a, b interface{}) bool {
 	return false
 }
 
-// noneOf will return true if b does not contain a
+// noneOf will return true if b (slice) does not contain a
 func noneOf(a, b interface{}) bool {
 	m, ok := b.(map[interface{}]struct{})
 	if !ok {

--- a/comparators_test.go
+++ b/comparators_test.go
@@ -215,6 +215,12 @@ func BenchmarkContains(b *testing.B) {
 	}
 }
 
+func BenchmarkStringContains(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		contains("1", "1")
+	}
+}
+
 func BenchmarkContainsLong50000(b *testing.B) {
 	var list []interface{}
 
@@ -253,6 +259,12 @@ func TestNotContains(t *testing.T) {
 func BenchmarkNotContains(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		contains([]string{"1", "2"}, "3")
+	}
+}
+
+func BenchmarkStringNotContains(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		contains("1", "3")
 	}
 }
 

--- a/comparators_test.go
+++ b/comparators_test.go
@@ -197,6 +197,8 @@ func TestContains(t *testing.T) {
 		testCase{args: []interface{}{[]interface{}{float64(1), float64(2)}, float64(1)}, expected: true},
 		testCase{args: []interface{}{[]interface{}{float64(1), float64(2)}, float64(3)}, expected: false},
 		testCase{args: []interface{}{[]interface{}{float64(1.01), float64(1.02)}, float64(1.01)}, expected: true},
+		testCase{args: []interface{}{"abc", "bc"}, expected: true},
+		testCase{args: []interface{}{"abc", "de"}, expected: false},
 	}
 
 	for i, c := range cases {
@@ -236,6 +238,8 @@ func TestNotContains(t *testing.T) {
 		testCase{args: []interface{}{[]interface{}{float64(1), float64(2)}, float64(1)}, expected: false},
 		testCase{args: []interface{}{[]interface{}{float64(1), float64(2)}, float64(3)}, expected: true},
 		testCase{args: []interface{}{[]interface{}{float64(1.01), float64(1.02)}, float64(1.01)}, expected: false},
+		testCase{args: []interface{}{"abc", "bc"}, expected: false},
+		testCase{args: []interface{}{"abc", "de"}, expected: true},
 	}
 
 	for i, c := range cases {


### PR DESCRIPTION
This PR allows the `contains` and `ncontains` comparators to operate on pure strings (which falls back to `strings.Contains`).  This allows the library to be a bit more robust.